### PR TITLE
fix(docs): typo Enviornment instead of Environment

### DIFF
--- a/blog/modules/ROOT/pages/introducing-pkl.adoc
+++ b/blog/modules/ROOT/pages/introducing-pkl.adoc
@@ -476,7 +476,7 @@ type Application struct {
 	Port uint16 `pkl:"port"`
 
 	// The environment to deploy to.
-	Environment Environment.Environment `pkl:"environment"`
+	Environment environment.Environment `pkl:"environment"`
 
 	// The database connection for this application
 	Database *Database `pkl:"database"`


### PR DESCRIPTION
Just a small typo mistake correction.