### PR TITLE
Fix site search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@antora/lunr-extension": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@antora/lunr-extension/-/lunr-extension-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-vdBgW3rsvbnmA236kT2Dckh9n0Db5za2/WxiLnFLgZ05ZO1KJQa9+R2WHaIFuGE7bKKbY+lqfM/i3KiezbL9YQ==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/lunr-extension/-/lunr-extension-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-q7BnPzFaL/DQhiH+NJ2d197cZNQoQriOd3aTHT2IaXGvC+ipbZMH9qUEIq6gm1LgIj8tLjiHZcPY6Xdnl9z+Ag==",
       "dependencies": {
         "cheerio": "1.0.0-rc.10",
         "html-entities": "~2.3",


### PR DESCRIPTION
Drop @antora/lunr-extension back to 1.0.0-alpha.4

Somehow, 1.0.0-alpha.8 is breaking the search; we get errors like "antoraSearch is not defined"