### PR TITLE
Fix broken Wiki link to DRY

### DIFF
--- a/blog/modules/ROOT/pages/introducing-pkl.adoc
+++ b/blog/modules/ROOT/pages/introducing-pkl.adoc
@@ -22,7 +22,7 @@ For example, their lack of expressivity means that code often gets repeated.
 Additionally, it can be easy to make configuration errors, because these formats do not provide any validation of their own.
 
 To address these shortcomings, sometimes formats get enhanced by ancillary tools that add special logic.
-For example, perhaps there’s a need to make code more link:https://en.wikipedia.org/wiki/Don't_repeat_yourself[pass:[<abbr title="Don't Repeat Yourself">DRY</abbr>]], so a special property is introduced that understands how to resolve references, and merge objects together.
+For example, perhaps there’s a need to make code more link:https://en.wikipedia.org/wiki/Don%27t_repeat_yourself[pass:[<abbr title="Don't Repeat Yourself">DRY</abbr>]], so a special property is introduced that understands how to resolve references, and merge objects together.
 Alternatively, there’s a need to guard against validation errors, so some new way is created to validate a configuration value against an expected type.
 Before long, these formats almost become programming languages, but ones that are hard to understand and hard to write.
 


### PR DESCRIPTION
This commit updates `introducing-pkl.adoc` to fix a broken Wiki link to the page on DRY. The link contains `'`, which won't work as is, and needs to be replaced by `%27`.