### PR TITLE
Fix mobile responsiveness

### DIFF
--- a/src/supplemental-ui/css/landing.css
+++ b/src/supplemental-ui/css/landing.css
@@ -95,7 +95,7 @@ body {
 }
 
 .logos {
-    min-width: 400px;
+    min-width: 370px;
 }
 
 .logos img[alt~="logo"] {
@@ -117,7 +117,7 @@ body {
     }
 
     .hero-duo > div {
-        max-width: unset;
+        max-width: 390px;
     }
 
     .secondary {


### PR DESCRIPTION
### Description

This pull request aims to fix landing page responsiveness on mobile devices (most notably iPhone Xr and above). It was determined that logos within the **Integrated application configuration** section and certain divs with the `.hero-duo` CSS class were causing a content overflow on sub-768px devices.

### Changes made

The problem was fixed by adjusting the following properties:
- `max-width` property value in the `@media` section,
- `min-width` property value in the `.logos` CSS class.

### Testing

Changes have been tested with Chrome DevTools using various devices presets (notably iPhone SE, Xr, 12 Pro, 14 Pro, as well as Galaxy S20 Ultra).

### Why is this important

This content overflow pushes the hamburger icon off-screen, as well as introduces inconsistent scrolling behaviour, both of which can potentially confuse the user.

### Screenshots of the problem

<img width="400" alt="image" src="https://github.com/apple/pkl-lang.org/assets/92231661/3a98406a-9f21-4072-8c32-fa4bfe8bd5c9">
