### PR TITLE
Add a prominent link to the standard library docs

### DIFF
--- a/src/supplemental-ui/partials/header-content.hbs
+++ b/src/supplemental-ui/partials/header-content.hbs
@@ -51,6 +51,7 @@
           <a href="{{siteRootPath}}/main/current/resources.html" class="navbar-link">Resources</a>
           <div class="navbar-dropdown">
             <a class="navbar-item" href="https://github.com/apple/pkl">GitHub</a>
+            <a class="navbar-item" href="https://pkl-lang.org/package-docs/pkl/current/index.html">Standard Library</a>
             <a class="navbar-item" href="https://pkl-lang.org/package-docs/">Package Docs</a>
             <a class="navbar-item" href="{{siteRootPath}}/main/current/style-guide/index.html">Style Guide</a>
             <a class="navbar-item" href="{{siteRootPath}}/security.html">Security</a>


### PR DESCRIPTION
Motivation: The standard library docs are some of the most important docs but currently very hard to find. I've noticed that even fairly advanced users have never heard of them and complain about "zero docs".