### PR TITLE
perf: Adding compile time optimization for rust 🦀

### DIFF
--- a/pkl-html-highlighter/Cargo.toml
+++ b/pkl-html-highlighter/Cargo.toml
@@ -12,6 +12,10 @@ clap = { version = "4.4.2", features = ["derive"] }
 [net]
 git-fetch-with-cli = true
 
+[profile.release]
+lto = true
+codegen-units = 1
+
 [[bin]]
 name = "pkl-html-highlighter"
 path = "src/main.rs"


### PR DESCRIPTION

This pull request enables Link Time Optimization (LTO) by setting `lto = true` and adjusts the code generation units to 1 (`codegen-units = 1`) in the `cargo.yaml` file for Rust language. This optimization aims to improve the performance of the Rust codebase by optimizing the linking process and reducing the number of code generation units, resulting in more efficient executable output.


Extremely sorry, If I made any mistakes :)
