### PR TITLE
Fix syntax highlighting of string interpolation

### DIFF
--- a/pkl-html-highlighter/queries/highlights.scm
+++ b/pkl-html-highlighter/queries/highlights.scm
@@ -46,18 +46,6 @@
 (intLiteralExpr) @number
 (floatLiteralExpr) @number
 
-(stringInterpolation
-  "\\(" @char.escape
-  ")" @char.escape) @subst
-
-(stringInterpolation
-  "\\#(" @char.escape
-  ")" @char.escape) @subst
-
-(stringInterpolation
-  "\\##(" @char.escape
-  ")" @char.escape) @subst
-
 (lineComment) @comment
 (blockComment) @comment
 (docComment) @comment
@@ -146,3 +134,15 @@
 "typealias" @keyword
 (unknownType) @type
 "when" @keyword
+
+(stringInterpolation
+  "\\(" @char.escape
+  ")" @char.escape) @subst
+
+(stringInterpolation
+  "\\#(" @char.escape
+  ")" @char.escape) @subst
+
+(stringInterpolation
+  "\\##(" @char.escape
+  ")" @char.escape) @subst


### PR DESCRIPTION
Looks like some tree-sitter-highlight release may have swapped around query order/precedence. Later queries appear to win now, so this PR moves the string interpolation queries to the end, after operators/punctuation.