### PR TITLE
Update syntax highlighting

### DIFF
--- a/pkl-html-highlighter/Cargo.lock
+++ b/pkl-html-highlighter/Cargo.lock
@@ -363,8 +363,8 @@ checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "tree-sitter-pkl"
-version = "0.20.0"
-source = "git+https://github.com/apple/tree-sitter-pkl.git?rev=ac58931956c000d3aeefbb55a81fc3c5bd6aecf0#ac58931956c000d3aeefbb55a81fc3c5bd6aecf0"
+version = "0.21.0"
+source = "git+https://github.com/apple/tree-sitter-pkl.git?rev=v0.21.0#5893fb5dc832ea51a9bff3f84462528c766ecd7d"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/pkl-html-highlighter/Cargo.toml
+++ b/pkl-html-highlighter/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["pkl-oss@group.apple.com"]
 
 [dependencies]
 tree-sitter-highlight = "0.26.9"
-tree-sitter-pkl = { git = "https://github.com/apple/tree-sitter-pkl.git", rev = "ac58931956c000d3aeefbb55a81fc3c5bd6aecf0" }
+tree-sitter-pkl = { git = "https://github.com/apple/tree-sitter-pkl.git", rev = "v0.21.0" }
 clap = { version = "4.6.1", features = ["derive"] }
 
 [net]

--- a/pkl-html-highlighter/queries/highlights.scm
+++ b/pkl-html-highlighter/queries/highlights.scm
@@ -146,3 +146,5 @@
 (stringInterpolation
   "\\##(" @char.escape
   ")" @char.escape) @subst
+
+(mlStringContinuation) @char.escape


### PR DESCRIPTION
* Update tree-sitter-pkl to latest release version
* Mark multiline string continuation as escape char

Screenshot:

<img width="821" height="178" alt="Screenshot 2026-07-29 at 11 21 21 AM" src="https://github.com/user-attachments/assets/e494cc42-149b-4223-ad7b-c662db14ade1" />
