### PR TITLE
Improve Gradle build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,35 +1,51 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @file:Suppress("UnstableApiUsage")
 
 import com.github.gradle.node.task.NodeTask
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
   base
   idea
   validateSite
   alias(libs.plugins.downloadGradle)
   alias(libs.plugins.nodeGradle)
+  alias(libs.plugins.spotless)
 }
 
 val isCi = System.getenv("CI") != null
 val isDocker = System.getenv("DOCKER") != null
 
 data class Site(
-  /** The name of the repo to clone */
-  val repo: String,
-  /** The branch to clone */
-  val branch: String,
-  /**
-   * The output directory.
-   *
-   * This will result in a subdirectory in the eventual deployment, e.g. pkl-lang.org/foo
-   */
-  val dirName: String = repo,
+    /** The name of the repo to clone */
+    val repo: String,
+    /** The branch to clone */
+    val branch: String,
+    /**
+     * The output directory.
+     *
+     * This will result in a subdirectory in the eventual deployment, e.g. pkl-lang.org/foo
+     */
+    val dirName: String = repo,
 )
 
-val additionalSites: List<Site> = listOf(
-  Site("pkl-package-docs", "www", "package-docs"),
-)
+val additionalSites: List<Site> =
+    listOf(
+        Site("pkl-package-docs", "www", "package-docs"),
+    )
 
 configurations {
   all {
@@ -52,186 +68,204 @@ idea {
   }
 }
 
-val cloneAdditionalSites by tasks.registering {
-  for (site in additionalSites) {
-    outputs.dir(layout.buildDirectory.dir(site.dirName))
-  }
-  doLast {
-    for (site in additionalSites) {
-      providers.exec {
-        val output = layout.buildDirectory.dir(site.dirName).get()
-        if (output.dir(".git").asFile.exists()) {
-          commandLine(
-            "git",
-            "pull",
-            "--ff-only",
-            "origin",
-            site.branch
-          )
-          workingDir(output)
-        } else {
-          commandLine(
-            "git",
-            "clone",
-            "--branch",
-            site.branch,
-            "https://github.com/apple/${site.repo}.git",
-            layout.buildDirectory.dir(site.dirName).get()
-          )
+val cloneAdditionalSites =
+    tasks.register("cloneAdditionalSites") {
+      for (site in additionalSites) {
+        outputs.dir(layout.buildDirectory.dir(site.dirName))
+      }
+      doLast {
+        for (site in additionalSites) {
+          providers
+              .exec {
+                val output = layout.buildDirectory.dir(site.dirName).get()
+                if (output.dir(".git").asFile.exists()) {
+                  commandLine(
+                      "git",
+                      "pull",
+                      "--ff-only",
+                      "origin",
+                      site.branch,
+                  )
+                  workingDir(output)
+                } else {
+                  commandLine(
+                      "git",
+                      "clone",
+                      "--branch",
+                      site.branch,
+                      "https://github.com/apple/${site.repo}.git",
+                      layout.buildDirectory.dir(site.dirName).get(),
+                  )
+                }
+              }
+              .result
+              .get()
         }
-      }.result.get()
-    }
-  }
-}
-
-val pklHtmlHighlighter by tasks.registering {
-  inputs.dir("pkl-html-highlighter/src")
-  inputs.dir("pkl-html-highlighter/queries")
-  inputs.file("pkl-html-highlighter/Cargo.lock")
-  inputs.file("pkl-html-highlighter/Cargo.toml")
-  doFirst {
-    providers.exec {
-      commandLine("cargo", "build")
-      workingDir = file("pkl-html-highlighter")
-    }.result.get()
-  }
-  outputs.file("pkl-html-highlighter/target/debug/pkl-html-highlighter")
-}
-
-val buildLocalSite by tasks.registering(NodeTask::class) {
-  dependsOn(pklHtmlHighlighter)
-  dependsOn(tasks.named("npmInstall"))
-  dependsOn(cloneAdditionalSites)
-
-  val outputDir = file("${project.layout.buildDirectory.get()}/local")
-
-  inputs.file("src/site-local.yml")
-  inputs.dir("src/supplemental-ui")
-  inputs.dir("src/highlighter")
-  inputs.dir("src/macros")
-  inputs.dir("../pkl/docs")
-  inputs.dir("../pkl-spring/docs")
-  inputs.dir("../pkl-intellij/docs")
-  inputs.dir("../pkl-vscode/docs")
-  inputs.dir("../pkl-neovim/docs")
-  inputs.dir("../pkl-lsp/docs")
-  inputs.dir("blog/")
-  inputs.dir("landing/")
-
-  outputs.dir(outputDir)
-
-  // Allows us to load TypeScript sources directly; used for Asciidoctor syntax highlighting
-  options.set(listOf("--require", "ts-node/register"))
-
-  script.set(file("./node_modules/.bin/antora"))
-
-  args.set(
-    listOf(
-      "--fetch",
-      "--stacktrace",
-      "src/site-local.yml",
-    )
-  )
-
-  doFirst {
-    execOverrides {
-      environment["FORCE_COLOR"] = "1"
-      environment["PKL_HTML_HIGHLIGHTER"] = pklHtmlHighlighter.get().outputs.files.first().absolutePath
-    }
-  }
-
-  doLast {
-    for (site in additionalSites) {
-      copy {
-        from(fileTree(layout.buildDirectory.dir(site.dirName).get()))
-        into("$outputDir/${site.dirName}")
       }
     }
-    println("\nGenerated local site at: file://$outputDir/index.html")
-  }
-}
 
-val buildRemoteSite by tasks.registering(NodeTask::class) {
-  dependsOn(pklHtmlHighlighter)
-  dependsOn(cloneAdditionalSites)
-  dependsOn(tasks.named("npmInstall"))
-
-  val outputDir = project.layout.buildDirectory.get().dir("remote")
-
-  inputs.file("src/site-remote.yml")
-  inputs.dir("src/supplemental-ui")
-  inputs.dir("src/highlighter")
-  inputs.dir("src/macros")
-  inputs.dir("blog/")
-  inputs.dir("landing/")
-  outputs.dir(outputDir)
-
-  script.set(file("./node_modules/.bin/antora"))
-
-  args.set(listOf(
-      "--stacktrace",
-      "src/site-remote.yml"
-  ))
-
-  // Allows us to load TypeScript sources directly; used for Asciidoctor syntax highlighting
-  options.set(listOf("--require", "ts-node/register"))
-
-  execOverrides {
-    environment["PKL_HTML_HIGHLIGHTER"] = pklHtmlHighlighter.get().outputs.files.first().absolutePath
-
-    val gitCredentials = System.getenv("ANTORA_GIT_FETCH")
-    if (gitCredentials != null) {
-      environment["GIT_CREDENTIALS"] = "https://${gitCredentials}:@github.com"
+val pklHtmlHighlighter =
+    tasks.register("pklHtmlHighlighter") {
+      inputs.dir("pkl-html-highlighter/src")
+      inputs.dir("pkl-html-highlighter/queries")
+      inputs.file("pkl-html-highlighter/Cargo.lock")
+      inputs.file("pkl-html-highlighter/Cargo.toml")
+      doFirst {
+        providers
+            .exec {
+              commandLine("cargo", "build")
+              workingDir = file("pkl-html-highlighter")
+            }
+            .result
+            .get()
+      }
+      outputs.file("pkl-html-highlighter/target/debug/pkl-html-highlighter")
     }
-  }
 
-  doLast {
-    for (site in additionalSites) {
-      copy {
-        from(fileTree(layout.buildDirectory.dir(site.dirName).get()))
-        into(outputDir.dir(site.dirName))
+val buildLocalSite =
+    tasks.register<NodeTask>("buildLocalSite") {
+      dependsOn(pklHtmlHighlighter)
+      dependsOn(tasks.named("npmInstall"))
+      dependsOn(cloneAdditionalSites)
+
+      val outputDir = file("${project.layout.buildDirectory.get()}/local")
+
+      inputs.file("src/site-local.yml")
+      inputs.dir("src/supplemental-ui")
+      inputs.dir("src/highlighter")
+      inputs.dir("src/macros")
+      inputs.dir("../pkl/docs")
+      inputs.dir("../pkl-spring/docs")
+      inputs.dir("../pkl-intellij/docs")
+      inputs.dir("../pkl-vscode/docs")
+      inputs.dir("../pkl-neovim/docs")
+      inputs.dir("../pkl-lsp/docs")
+      inputs.dir("blog/")
+      inputs.dir("landing/")
+
+      outputs.dir(outputDir)
+
+      // Allows us to load TypeScript sources directly; used for Asciidoctor syntax highlighting
+      options.set(listOf("--require", "ts-node/register"))
+
+      script.set(file("./node_modules/.bin/antora"))
+
+      args.set(
+          listOf(
+              "--fetch",
+              "--stacktrace",
+              "src/site-local.yml",
+          )
+      )
+
+      doFirst {
+        execOverrides {
+          environment["FORCE_COLOR"] = "1"
+          environment["PKL_HTML_HIGHLIGHTER"] =
+              pklHtmlHighlighter.get().outputs.files.first().absolutePath
+        }
+      }
+
+      doLast {
+        for (site in additionalSites) {
+          copy {
+            from(fileTree(layout.buildDirectory.dir(site.dirName).get()))
+            into("$outputDir/${site.dirName}")
+          }
+        }
+        println("\nGenerated local site at: file://$outputDir/index.html")
       }
     }
-    println("\nGenerated remote site at: file://${outputDir}/index.html")
-  }
-}
 
-val publishRemoteSite by tasks.registering(Exec::class) {
-  // important to run this as a self-contained CI step with GitHub deploy key,
-  // hence no task dependency on `buildRemoteSite`
+val buildRemoteSite =
+    tasks.register<NodeTask>("buildRemoteSite") {
+      dependsOn(pklHtmlHighlighter)
+      dependsOn(cloneAdditionalSites)
+      dependsOn(tasks.named("npmInstall"))
 
-  executable = "bash"
+      val outputDir = project.layout.buildDirectory.get().dir("remote")
 
-  val dollar = "$"
+      inputs.file("src/site-remote.yml")
+      inputs.dir("src/supplemental-ui")
+      inputs.dir("src/highlighter")
+      inputs.dir("src/macros")
+      inputs.dir("blog/")
+      inputs.dir("landing/")
+      outputs.dir(outputDir)
 
-  args(listOf(
-      "-c",
-      """
-        set -ex
+      script.set(file("./node_modules/.bin/antora"))
 
-        BRANCH_NAME=$dollar(git symbolic-ref -q HEAD)
-        BRANCH_NAME=$dollar{BRANCH_NAME##refs/heads/}
-        git fetch origin +gh-pages:gh-pages
-        git worktree add gh-pages gh-pages
-        cd gh-pages
+      args.set(
+          listOf(
+              "--stacktrace",
+              "src/site-remote.yml",
+          )
+      )
 
-        rm -rf *
-        touch .nojekyll
-        echo "pkl-lang.org" > CNAME
-        cp -r ../build/remote/* .
-        git add * .nojekyll
+      // Allows us to load TypeScript sources directly; used for Asciidoctor syntax highlighting
+      options.set(listOf("--require", "ts-node/register"))
 
-        git config --global user.email "pkl-oss@group.apple.com"
-        git config --global user.name "Pkl CI"
-        git commit -m "Publish docsite [skip ci]"
-        git push origin gh-pages
+      execOverrides {
+        environment["PKL_HTML_HIGHLIGHTER"] =
+            pklHtmlHighlighter.get().outputs.files.first().absolutePath
 
-        cd ..
-        rm -rf gh-pages
-        git worktree prune
-      """.trimIndent()
-  ))
-}
+        val gitCredentials = System.getenv("ANTORA_GIT_FETCH")
+        if (gitCredentials != null) {
+          environment["GIT_CREDENTIALS"] = "https://${gitCredentials}:@github.com"
+        }
+      }
+
+      doLast {
+        for (site in additionalSites) {
+          copy {
+            from(fileTree(layout.buildDirectory.dir(site.dirName).get()))
+            into(outputDir.dir(site.dirName))
+          }
+        }
+        println("\nGenerated remote site at: file://${outputDir}/index.html")
+      }
+    }
+
+val publishRemoteSite =
+    tasks.register<Exec>("publishRemoteSite") {
+      // important to run this as a self-contained CI step with GitHub deploy key,
+      // hence no task dependency on `buildRemoteSite`
+
+      executable = "bash"
+
+      val dollar = "$"
+
+      args(
+          listOf(
+              "-c",
+              """
+              set -ex
+
+              BRANCH_NAME=$dollar(git symbolic-ref -q HEAD)
+              BRANCH_NAME=$dollar{BRANCH_NAME##refs/heads/}
+              git fetch origin +gh-pages:gh-pages
+              git worktree add gh-pages gh-pages
+              cd gh-pages
+
+              rm -rf *
+              touch .nojekyll
+              echo "pkl-lang.org" > CNAME
+              cp -r ../build/remote/* .
+              git add * .nojekyll
+
+              git config --global user.email "pkl-oss@group.apple.com"
+              git config --global user.name "Pkl CI"
+              git commit -m "Publish docsite [skip ci]"
+              git push origin gh-pages
+
+              cd ..
+              rm -rf gh-pages
+              git worktree prune
+              """
+                  .trimIndent(),
+          )
+      )
+    }
 
 buildscript {
   repositories {
@@ -241,4 +275,32 @@ buildscript {
 
 repositories {
   mavenCentral()
+}
+
+val blockHeader =
+    $$"""
+    /**
+     * Copyright © $YEAR Apple Inc. and the Pkl project authors. All rights reserved.
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *     https://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+    """
+        .trimIndent()
+
+spotless {
+  kotlinGradle {
+    ktfmt(libs.versions.ktfmt.get())
+    target("*.gradle.kts", "buildSrc/**/*.kt", "buildSrc/**/*.kts")
+    licenseHeader(blockHeader, "([a-zA-Z]|@file|//)")
+  }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,8 +1,24 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
   `kotlin-dsl`
 }
 
-// IntelliJ doesn't currently understand statically typed access to the version catalog from this file.
+// IntelliJ doesn't currently understand statically typed access to the version catalog from this
+// file.
 // Hence we work around by using the dynamic API.
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 dependencyResolutionManagement {
   // use same version catalog as main build
   versionCatalogs {

--- a/buildSrc/src/main/kotlin/validateSite.gradle.kts
+++ b/buildSrc/src/main/kotlin/validateSite.gradle.kts
@@ -1,7 +1,20 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @file:Suppress("UnnecessaryVariable", "UnstableApiUsage")
 
-import java.util.concurrent.TimeUnit
-import org.jsoup.Jsoup
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
@@ -9,14 +22,20 @@ import java.net.URISyntaxException
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
+import org.jsoup.Jsoup
 
 // links that are allowed to be http rather than https
 val httpLinks = listOf<String>()
 
 // links to exclude from validation (for example because they require authentication)
-val excludedLinks = listOf(
-    "https://www.oracle.com/technetwork/java",
-)
+val excludedLinks =
+    listOf(
+        "https://www.oracle.com/technetwork/java",
+    )
 
 configurations {
   register("nuValidator")
@@ -33,47 +52,56 @@ dependencies {
 
 for (location in listOf("local", "remote")) {
   val capitalizedLocation = location.replaceFirstChar { it.titlecase(Locale.getDefault()) }
-  val htmlFiles = fileTree("${layout.buildDirectory.get()}/$location").matching { include("**/*.html") }
+  val htmlFiles =
+      fileTree("${layout.buildDirectory.get()}/$location").matching {
+        include("**/*.html")
+        // exclude validating HTML in package docs; these are generated from pkldoc and we care less if there's broken
+        // links
+        exclude("**/package-docs/**")
+      }
 
   val buildSiteTask = "build${capitalizedLocation}Site" // defined in /build.gradle.kts
   val validateSiteTask = tasks.register("validate${capitalizedLocation}Site")
-  val configureValidateHtmlFilesTask = tasks.register("configureValidate${capitalizedLocation}HtmlFiles")
-  val validateHtmlFilesTask = tasks.register("validate${capitalizedLocation}HtmlFiles", JavaExec::class)
+  val validateHtmlFilesTask =
+      tasks.register("validate${capitalizedLocation}HtmlFiles", JavaExec::class)
   val validateHtmlLinksTask = tasks.register("validate${capitalizedLocation}HtmlLinks")
 
   validateSiteTask.configure {
     dependsOn(validateHtmlFilesTask, validateHtmlLinksTask)
   }
 
-  configureValidateHtmlFilesTask.configure {
-    doLast {
-      validateHtmlFilesTask.get().args(htmlFiles)
-    }
-  }
-
   validateHtmlFilesTask.configure {
-
-
-    dependsOn(configureValidateHtmlFilesTask, buildSiteTask)
+    dependsOn(buildSiteTask)
 
     val outputFile = file("${layout.buildDirectory.get()}/report/validateHtmlFiles/result.txt")
+    val argFile = project.layout.buildDirectory.file("tmp/${name}/args.txt").get().asFile.toPath()
 
     inputs.files(htmlFiles)
     outputs.file(outputFile)
 
     classpath = configurations["nuValidator"]
     mainClass.set("nu.validator.client.SimpleCommandLineValidator")
-    args("--skip-non-html") // --also-check-css doesn't work (still checks css as html), so limit to html files
+    args(
+        "--skip-non-html"
+    ) // --also-check-css doesn't work (still checks css as html), so limit to html files
     args("--filterpattern", "(.*)Consider adding “lang=(.*)")
     args("--filterpattern", "(.*)The “main” role is unnecessary for element “main”(.*)")
     args("--filterpattern", "(.*)Consider adding a “lang” attribute(.*)")
+    args("@${argFile.absolutePathString()}")
     // for debugging
     // args("--verbose")
 
     // write a basic result file s.t. gradle can consider task up-to-date
-    // writing a result file in case validation fails is not easily possible with JavaExec, but also not strictly necessary
-    doFirst { delete(outputFile) }
-    doLast { outputFile.writeText("Success.") }
+    // writing a result file in case validation fails is not easily possible with JavaExec, but also
+    // not strictly necessary
+    doFirst {
+      delete(outputFile)
+      argFile.createParentDirectories()
+      argFile.writeText(htmlFiles.joinToString("\n") { it.absolutePath })
+    }
+    doLast {
+      outputFile.writeText("Success.")
+    }
   }
 
   validateHtmlLinksTask.configure {
@@ -90,7 +118,7 @@ for (location in listOf("local", "remote")) {
       val seenLinks = mutableSetOf<String>()
 
       try {
-			  // only validate links of latest version because we can't fix links of older versions
+        // only validate links of latest version because we can't fix links of older versions
         for (htmlFile in htmlFiles) {
           val htmlText = htmlFile.readText()
           val unresolvedXrefs = Regex("""xref:\S*""").findAll(htmlText)
@@ -111,12 +139,13 @@ for (location in listOf("local", "remote")) {
             // check each link just once
             if (!seenLinks.add(href)) continue
 
-            val uri = try {
-              URI(href)
-            } catch (e: URISyntaxException) {
-              errors.add("$htmlFile: Invalid link URL: $link (Error message: ${e.message})")
-              continue
-            }
+            val uri =
+                try {
+                  URI(href)
+                } catch (e: URISyntaxException) {
+                  errors.add("$htmlFile: Invalid link URL: $link (Error message: ${e.message})")
+                  continue
+                }
             if (uri.scheme == null) {
               if (href == "" || href == "#") {
                 val id = link.attributes().get("id")
@@ -132,7 +161,10 @@ for (location in listOf("local", "remote")) {
               }
             } else if (uri.scheme == "mailto") {
               // not validated
-            } else if (uri.scheme == "https" || uri.scheme == "http" && httpLinks.any { uri.toString().startsWith(it) }) {
+            } else if (
+                uri.scheme == "https" ||
+                    uri.scheme == "http" && httpLinks.any { uri.toString().startsWith(it) }
+            ) {
               // capture values because variables will change while executor is running
               val submittedUri = uri
               val submittedHref = href
@@ -149,13 +181,19 @@ for (location in listOf("local", "remote")) {
                 try {
                   conn.connect()
                   val responseCode = conn.responseCode
-                  if (responseCode != 200 &&
-                      responseCode != 403 /* github auth */ &&
-                      responseCode != 429 /* github rate limiting */) {
-                    errors.add("$submittedHtmlFile: Unexpected HTTP status code `$responseCode` for external link `$submittedHref`.")
+                  if (
+                      responseCode != 200 &&
+                          responseCode != 403 /* github auth */ &&
+                          responseCode != 429 /* github rate limiting */
+                  ) {
+                    errors.add(
+                        "$submittedHtmlFile: Unexpected HTTP status code `$responseCode` for external link `$submittedHref`."
+                    )
                   }
                 } catch (e: IOException) {
-                  println("Ignoring I/O error for external link `$submittedHref`. (Error message: ${e.message})")
+                  println(
+                      "Ignoring I/O error for external link `$submittedHref`. (Error message: ${e.message})"
+                  )
                 } finally {
                   conn.disconnect()
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,15 +6,19 @@ jsoup="1.22.2"
 # use same Node version as Docker image
 # https://nodejs.org/download/release/latest-v16.x/
 node="16.13.1"
+#noinspection UnusedVersionCatalogEntry
+ktfmt = "0.64"
 # https://plugins.gradle.org/plugin/com.github.node-gradle.node
 nodeGradle="7.1.0"
 # https://search.maven.org/artifact/nu.validator/validator
 nuValidator="26.7.3"
+spotlessPlugin = "8.8.0"
 
 [libraries] # ordered alphabetically
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 nuValidator = { group = "nu.validator", name = "validator", version.ref = "nuValidator" }
 
 [plugins] # ordered alphabetically
-nodeGradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }
 downloadGradle = { id = "de.undercouch.download", version.ref = "downloadGradle" }
+nodeGradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin"}

--- a/landing/modules/ROOT/pages/threat-model.adoc
+++ b/landing/modules/ROOT/pages/threat-model.adoc
@@ -346,7 +346,7 @@ This could allow a Pkl module to read files outside `--root-dir`, access network
 ==== Allowlist Bypass via Crafted URI
 
 A crafted URI causes an allowlist regex to match more broadly than the operator intended.
-For example, a pattern meant to allow `https://example.com/` also matches `https://example.com.evil.com/` due to a missing anchor.
+For example, a pattern meant to allow `\https://example.com/` also matches `\https://example.com.evil.com/` due to a missing anchor.
 The runtime is the last line of defense against such gaps.
 
 *Attacker:* Remote Attacker; Malicious Module Author +

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,22 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 rootProject.name = "pkl-lang.org"
 
 val javaVersion = JavaVersion.current()
+
 require(javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
   "Project requires Java 17 or higher, but found ${javaVersion.majorVersion}."
 }


### PR DESCRIPTION
* Use argfile to pass in HTML when validating site
* Prevent site validator from checking pkldoc-generated contents; there's not much to do if something fails
* Add spotless formatting and license headers