### PR TITLE
Add colors to error output on landing page

### DIFF
--- a/blog/modules/ROOT/pages/testing-in-pkl.adoc
+++ b/blog/modules/ROOT/pages/testing-in-pkl.adoc
@@ -54,17 +54,17 @@ facts {
 
 Running this test provides a report about the failing test.
 
-[source,text]
+[source%ansi,text]
 ----
-$ pkl test math.pkl
 module math
   facts
-    ✘ one
-       1 + 5 == 3 (file:///math.pkl, line 8)
-         │   │
-         6   false
+    [31m✘ [0m[2mone[0m
+       [0m1 + 5 == 3 [2m(file:///math.pkl, line 7[0m[2m)[0m
+         [2m│[0m   [2m│[0m
+         [32m6[0m   [36mfalse[0m
 
-0.0% tests pass [1/1 failed], 66.6% asserts pass [1/3 failed]
+[31m0.0% tests pass[0m [1/1 failed], [31m66.6% asserts pass[0m [1/3 failed]
+
 ----
 
 Test failures show a _power assertion_ about the failing test (introduced in Pkl 0.31).
@@ -173,13 +173,13 @@ examples {
 
 Running `pkl test person.pkl` again now shows that it passes.
 
-[source]
+[source%ansi,text]
 ----
-module test
+module person
   examples
-    ✔ person
+    [32m✔ [0m[2mperson[0m
 
-100.0% tests pass [1 passed], 100.0% asserts pass [1 passed]
+[32m100.0% tests pass[0m [1 passed], [32m100.0% asserts pass[0m [1 passed]
 ----
 
 Now, we'll change "Johnny" to "Sally", to demonstrate a test failure.
@@ -199,26 +199,27 @@ Now, we'll change "Johnny" to "Sally", to demonstrate a test failure.
 
 Running `pkl test person.pkl` again fails.
 
-[source]
+[source%ansi,text]
 ----
-module test
+module person
   examples
-    ✘ person
-       #0: (file:///test.pkl, line 13)
-         Expected: (file:///test.pkl-expected.pcf, line 3)
-         new {
+    [31m✘ [0m[2mperson[0m
+       [2m#0: [31m(file:///person.pkl, line 13[0m[2;31m)[0m[31m
+         Expected: [2m(file:///person.pkl-expected.pcf, line 3[0m[2;31m)[0m[31m
+         [1mnew {
            firstName = "Johnny"
            lastName = "Appleseed"
            fullName = "Johnny Appleseed"
-         }
-         Actual: (file:///test.pkl-actual.pcf, line 3)
-         new {
+         }[0m[31m
+         Actual: [2m(file:///person.pkl-actual.pcf, line 3[0m[2;31m)[0m[31m
+         [1mnew {
            firstName = "Sally"
            lastName = "Appleseed"
            fullName = "Sally Appleseed"
-         }
+         }[0m
 
-0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
+[31m0.0% tests pass[0m [1/1 failed], [31m0.0% asserts pass[0m [1/1 failed]
+
 ----
 
 Because the test failed, Pkl writes a new file to the same directory. The directory tree now looks like this:
@@ -261,7 +262,7 @@ For intentional changes, add the `--overwrite` flag. This will overwrite the exp
 [source]
 ----
 $ pkl test person.pkl --overwrite
-module test
+module person
   examples
     ✍️ person
 

--- a/buildSrc/src/main/kotlin/validateSite.gradle.kts
+++ b/buildSrc/src/main/kotlin/validateSite.gradle.kts
@@ -55,8 +55,8 @@ for (location in listOf("local", "remote")) {
   val htmlFiles =
       fileTree("${layout.buildDirectory.get()}/$location").matching {
         include("**/*.html")
-        // exclude validating HTML in package docs; these are generated from pkldoc and we care less if there's broken
-        // links
+        // exclude validating HTML in package docs; these are generated from pkldoc and we care less
+        // if there's broken links
         exclude("**/package-docs/**")
       }
 

--- a/landing/modules/ROOT/pages/index.adoc
+++ b/landing/modules/ROOT/pages/index.adoc
@@ -346,22 +346,28 @@ port: Int(this > 1000) = 80
 [.hero-arrow]
 ↓
 
-[source,shell]
+[source,ansi]
 ----
-–– Pkl Error ––
-Type constraint `this > 1000` violated.
+[31m–– Pkl Error ––[0m
+[1;31mType constraint `this > 1000` violated.
 Value: 80
 
-3 | port: Int(this > 1000) = 80
-              ^^^^^^^^^^^
-at config#port (config.pkl, line 3)
+[0m    this > 1000
+    [2m│[0m    [2m│[0m
+    [32m80[0m   [36mfalse[0m[1;31m[0m
 
-3 | port: Int(this > 1000) = 80
-                             ^^
-at config#port (config.pkl, line 3)
+[33m[0m[2m3 | [0mport: Int([34mthis[0m [0m>[0m [32m1000[0m) = [32m80[0m
+[33m[0m              [31m^^^^^^^^^^^[0m
+[33m[0m[2mat config#port (file:///config.pkl, line 3[0m[2m)
+[0m[33m[0m
+[33m[0m[2m3 | [0mport: Int([34mthis[0m [0m>[0m [32m1000[0m) = [32m80[0m
+[33m[0m                             [31m^^[0m
+[33m[0m[2mat config#port (file:///config.pkl, line 3[0m[2m)
+[0m[33m[0m
+[33m[0m[2m131 | [0mrenderer.renderDocument(value)
+[33m[0m      [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+[33m[0m[2mat pkl.base#Module.output.text
 
-106 | text = renderer.renderDocument(value)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ----
 
 ======

--- a/landing/modules/ROOT/pages/index.adoc
+++ b/landing/modules/ROOT/pages/index.adoc
@@ -346,7 +346,7 @@ port: Int(this > 1000) = 80
 [.hero-arrow]
 ↓
 
-[source,ansi]
+[source%ansi,text]
 ----
 [31m–– Pkl Error ––[0m
 [1;31mType constraint `this > 1000` violated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@types/vinyl": "^2.0.12",
+        "fancy-ansi": "^0.1.3",
         "feed": "^4.2.2"
       },
       "engines": {
@@ -1106,6 +1107,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1122,6 +1130,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fancy-ansi": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fancy-ansi/-/fancy-ansi-0.1.3.tgz",
+      "integrity": "sha512-tRQVTo5jjdSIiydqgzIIEZpKddzSsfGLsSVt6vWdjVm7fbvDTiQkyoPu6Z3dIPlAM4OZk0jP5jmTCX4G8WGgBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "escape-html": "^1.0.3"
       }
     },
     "node_modules/fast-copy": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/vinyl": "^2.0.12",
+    "fancy-ansi": "^0.1.3",
     "feed": "^4.2.2"
   }
 }

--- a/src/highlighter/processor.ts
+++ b/src/highlighter/processor.ts
@@ -58,7 +58,8 @@ function processSourceBlock(processor: TreeProcessor, block: Asciidoctor.Documen
   // noinspection TypeScriptValidateJSTypes
   const blockLanguage: string = block.getAttribute("language")
     || block.getDocument().getAttribute("highlightjs-default-lang", "none");
-  if (blockLanguage != "pkl-snippet" && blockLanguage != "pkl" && blockLanguage != "pkl expression" && blockLanguage != "ansi") {
+  const isAnsi = block.isOption("ansi");
+  if (blockLanguage != "pkl-snippet" && blockLanguage != "pkl" && blockLanguage != "pkl expression" && !isAnsi) {
     return;
   }
   let callouts: ReturnType<typeof calloutSubstituter> | null = null;
@@ -76,7 +77,7 @@ function processSourceBlock(processor: TreeProcessor, block: Asciidoctor.Documen
     subs.splice(0, idx + 1)  // remove subs until specialcharacters (incl.)
   }
 
-  const html = blockLanguage == "ansi" ? highlightAnsi(source) : highlightPkl(source, blockLanguage);
+  const html = isAnsi ? highlightAnsi(source) : highlightPkl(source, blockLanguage);
   let lines = html.split("\n");
 
   if (callouts != null) {

--- a/src/highlighter/processor.ts
+++ b/src/highlighter/processor.ts
@@ -17,8 +17,8 @@ import { Asciidoctor } from "asciidoctor";
 import { spawnSync } from "child_process";
 import TreeProcessor = Asciidoctor.Extensions.TreeProcessor;
 import calloutSubstituter from "./calloutSubstituter";
-import path from "path";
-import hljs from "highlight.js/lib/common"
+// @ts-ignore
+import { FancyAnsi } from "fancy-ansi";
 
 export function highlightPkl(source: string, lang: string): string {
   const pklHtmlHighlighterPath = process.env["PKL_HTML_HIGHLIGHTER"] || "pkl-html-highlighter";
@@ -40,6 +40,11 @@ export function highlightPkl(source: string, lang: string): string {
   return cmd.stdout;
 }
 
+function highlightAnsi(source: string): string {
+  const fancyAnsi = new FancyAnsi();
+  return fancyAnsi.toHtml(source);
+}
+
 function removeSubstitution (block: Asciidoctor.Document, name: string): string | undefined {
   // @ts-ignore
   if (block.hasSubstitution(name)) {
@@ -53,7 +58,7 @@ function processSourceBlock(processor: TreeProcessor, block: Asciidoctor.Documen
   // noinspection TypeScriptValidateJSTypes
   const blockLanguage: string = block.getAttribute("language")
     || block.getDocument().getAttribute("highlightjs-default-lang", "none");
-  if (blockLanguage != "pkl-snippet" && blockLanguage != "pkl" && blockLanguage != "pkl expression") {
+  if (blockLanguage != "pkl-snippet" && blockLanguage != "pkl" && blockLanguage != "pkl expression" && blockLanguage != "ansi") {
     return;
   }
   let callouts: ReturnType<typeof calloutSubstituter> | null = null;
@@ -71,7 +76,7 @@ function processSourceBlock(processor: TreeProcessor, block: Asciidoctor.Documen
     subs.splice(0, idx + 1)  // remove subs until specialcharacters (incl.)
   }
 
-  const html = highlightPkl(source, blockLanguage);
+  const html = blockLanguage == "ansi" ? highlightAnsi(source) : highlightPkl(source, blockLanguage);
   let lines = html.split("\n");
 
   if (callouts != null) {

--- a/src/supplemental-ui/css/theme-vars.css
+++ b/src/supplemental-ui/css/theme-vars.css
@@ -48,13 +48,11 @@
   --color-admonition-caution: #ffe6e6;
   --color-admonition-important: #ffe6e6;
 
-  /* NOTE: we currently don't need a separate set for light mode vs. dark mode because we only use ansi highlighting on
-   the landing page, and the landing page's code blocks are always dark. */
-  --ansi-red: #ff7e7e;
-  --ansi-green: #00C600;
-  --ansi-cyan: #00C9CA;
-  --ansi-blue: #77A2C4;
+  --ansi-cyan: #009a9a;
+  --ansi-green: #108c10;
+  --ansi-red: #d14;
   --ansi-yellow: #C8C400;
+  --ansi-blue: #015dc5;
   --ansi-dim-opacity: 0.5;
 }
 
@@ -100,6 +98,12 @@
   --color-admonition-warning: #3a331f;
   --color-admonition-caution: #3a1f1f;
   --color-admonition-important: #3a1f1f;
+
+  --ansi-red: #ff7e7e;
+  --ansi-green: #00c600;
+  --ansi-cyan: #00bdbd;
+  --ansi-blue: #77a2c4;
+  --ansi-yellow: #c8c400;
 }
 
 /* Apply theme colors to elements */

--- a/src/supplemental-ui/css/theme-vars.css
+++ b/src/supplemental-ui/css/theme-vars.css
@@ -47,6 +47,15 @@
   --color-admonition-warning: #fff8e6;
   --color-admonition-caution: #ffe6e6;
   --color-admonition-important: #ffe6e6;
+
+  /* NOTE: we currently don't need a separate set for light mode vs. dark mode because we only use ansi highlighting on
+   the landing page, and the landing page's code blocks are always dark. */
+  --ansi-red: #ff7e7e;
+  --ansi-green: #00C600;
+  --ansi-cyan: #00C9CA;
+  --ansi-blue: #77A2C4;
+  --ansi-yellow: #C8C400;
+  --ansi-dim-opacity: 0.5;
 }
 
 /* Dark theme overrides */


### PR DESCRIPTION
* Make source blocks transform ANSI escape codes when `%ansi` is added as an option 
* Update landing page and "Testing in Pkl" blog post to use ansi escapes

Preview:

<img width="1292" height="742" alt="Screenshot 2026-08-07 at 2 51 33 PM" src="https://github.com/user-attachments/assets/4ce979bb-f5c4-40b2-b488-b0143e829e61" />
<img width="773" height="568" alt="Screenshot 2026-08-09 at 8 18 57 PM" src="https://github.com/user-attachments/assets/1f09e9d8-e5fe-456b-b90a-0b947dc9d84a" />
