### PR TITLE
Import "Community" page from pkl, add "community calls" section

### DIFF
--- a/landing/modules/ROOT/pages/community.adoc
+++ b/landing/modules/ROOT/pages/community.adoc
@@ -1,0 +1,17 @@
+= Community
+:uri-github-issue: https://github.com/apple/pkl/issues
+:uri-github-discussions: https://github.com/apple/pkl/discussions
+
+We'd love to hear from you!
+
+* Create an {uri-github-issue}[issue]
+* Ask questions on {uri-github-discussions}[GitHub Discussions]
+* Join a <<community-calls,community call>>
+
+[[community-calls]]
+== Community Calls
+
+Every two weeks on Wednesday, we host a community call to chat about the development of Pkl.
+If you're interested in, or actively working on a feature in the Pkl ecosystem, you're invited to join!
+
+For dial-in details, see the https://github.com/apple/pkl/discussions/1164[Pkl Community Calls] discussion on GitHub.

--- a/landing/nav.adoc
+++ b/landing/nav.adoc
@@ -1,2 +1,3 @@
+* xref:ROOT:community.adoc[]
 * xref:ROOT:security.adoc[]
 ** xref:ROOT:threat-model.adoc[]

--- a/src/supplemental-ui/partials/header-content.hbs
+++ b/src/supplemental-ui/partials/header-content.hbs
@@ -59,7 +59,7 @@
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">
-          <a href="{{siteRootPath}}/main/current/community.html" class="navbar-link">Community</a>
+          <a href="{{siteRootPath}}/community.html" class="navbar-link">Community</a>
           <div class="navbar-dropdown is-right">
             <a class="navbar-item" href="https://github.com/apple/pkl/discussions" target="_blank">GitHub Discussions</a>
             <a class="navbar-item" href="{{siteRootPath}}/blog/index.html">Blog</a>


### PR DESCRIPTION
This page doesn't really belong in the apple/pkl repo.

Also, this adds a section about our bi-weekly community calls.

Related PR: https://github.com/apple/pkl/pull/1820