### PR TITLE
Add landing page buttons for tutorial and installation

### DIFF
--- a/landing/modules/ROOT/pages/index.adoc
+++ b/landing/modules/ROOT/pages/index.adoc
@@ -14,7 +14,17 @@
 [.title]
 ======
 Configuration that is *Programmable*, *Scalable*, and *Safe*
+
+[subs=macros]
+++++
+<div class="hero-actions">
+<!--xref:main:language-tutorial:index.adoc[Get Started]-->
+xref:main:pkl-cli:index.adoc#installation[Install]
+</div>
+++++
 ======
+
+
 ++++
 <div class="separator"></div>
 ++++

--- a/src/supplemental-ui/css/landing.css
+++ b/src/supplemental-ui/css/landing.css
@@ -33,6 +33,29 @@ body {
   color: #fff;
 }
 
+.hero-actions {
+  display: flex;
+  flex: 1 1;
+  flex-wrap: wrap;
+  flex-direction: row;
+  grid-column: 1 / 2;
+  gap: 1.3125rem;
+  justify-content: center;
+}
+
+.hero-actions a, .hero-actions a:visited, .hero-actions a:hover {
+  width: 100%;
+  max-width: 17.5rem;
+  padding: 1rem 0;
+  background-color: #6b9543;
+  color: #fff;
+  border-radius: 0.25rem;
+  border: 0.0625rem solid #6b9543;
+  box-shadow: 0 0.125rem 0.3125rem 0 rgba(0, 0, 0, 0.2);
+  text-decoration: none;
+  text-align: center;
+}
+
 .hero-duo {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Open to input on button titles and exactly which pages these link to.

Here's what this looks like on desktop:

<img width="1642" height="463" alt="Screenshot 2026-08-24 at 2 16 59 PM" src="https://github.com/user-attachments/assets/caf29861-9fe5-48c2-9ebb-596c30a715fb" />

And mobile:

<img width="554" height="508" alt="Screenshot 2026-08-24 at 2 16 54 PM" src="https://github.com/user-attachments/assets/e3c9dca2-5a07-49d7-97dd-73ef7fff68de" />
