### PR TITLE
Adjust size and layout of hero button

### DIFF
--- a/src/supplemental-ui/css/landing.css
+++ b/src/supplemental-ui/css/landing.css
@@ -41,12 +41,13 @@ body {
   grid-column: 1 / 2;
   gap: 1.3125rem;
   justify-content: center;
+  padding-top: 5rem;
 }
 
 .hero-actions a, .hero-actions a:visited, .hero-actions a:hover {
   width: 100%;
   max-width: 17.5rem;
-  padding: 1rem 0;
+  padding: 0.6rem 0;
   background-color: #6b9543;
   color: #fff;
   border-radius: 0.25rem;
@@ -54,6 +55,7 @@ body {
   box-shadow: 0 0.125rem 0.3125rem 0 rgba(0, 0, 0, 0.2);
   text-decoration: none;
   text-align: center;
+  font-size: 1.3rem;
 }
 
 .hero-duo {


### PR DESCRIPTION
The spacing seemed a little too tight and big

Before:

<img width="1400" height="470" alt="Screenshot 2026-08-25 at 11 55 14 AM" src="https://github.com/user-attachments/assets/3ea77a73-1d1a-4f7b-bd2b-8e4bb2db2eb4" />
<img width="364" height="452" alt="Screenshot 2026-08-25 at 11 55 30 AM" src="https://github.com/user-attachments/assets/4c37a073-b9d1-46ad-8716-31337edc59d4" />

After:

<img width="1396" height="533" alt="Screenshot 2026-08-25 at 11 54 19 AM" src="https://github.com/user-attachments/assets/4e2c6b6c-23d7-4474-a9f8-eb1382f1b600" />
<img width="359" height="509" alt="Screenshot 2026-08-25 at 11 54 47 AM" src="https://github.com/user-attachments/assets/44c548e3-a652-4372-99ec-6f3fc9691968" />
